### PR TITLE
Adjust terminal highlighting colors for code

### DIFF
--- a/colors/pencil.vim
+++ b/colors/pencil.vim
@@ -93,8 +93,8 @@ hi Debug           guifg=#C30771                             ctermfg=darkred
 
 hi Underlined     guifg=fg                                   ctermfg=fg
 hi Ignore         guifg=bg                                   ctermfg=bg
-hi Error          guifg=#FFFFFF    guibg=#D75F5F        ctermfg=231    ctermbg=167
-hi Todo           guifg=#D7D7FF    guibg=bg    gui=none ctermfg=189    ctermbg=bg     cterm=none
+hi Error          guifg=#FFFFFF    guibg=#D75F5F        ctermfg=231     ctermbg=167    cterm=bold
+hi Todo           guifg=#D7D7FF    guibg=bg    gui=none ctermfg=231     ctermbg=red    cterm=bold
 
 "
 " minor groups
@@ -133,10 +133,10 @@ hi Question       guifg=DarkRed                          ctermfg=38
 hi Folded          guifg=#808080    guibg=bg       ctermfg=244    ctermbg=bg
 hi FoldColumn      guifg=#5FD7AF    guibg=bg       ctermfg=79     ctermbg=bg
 hi SignColumn      guifg=#5FD7AF    guibg=bg       ctermfg=79     ctermbg=bg
-hi ColorColumn     guifg=#5FD7AF    guibg=#D9D9D9  ctermfg=79     ctermbg=bg
+hi ColorColumn     guifg=#5FD7AF    guibg=#D9D9D9                 ctermbg=79
 
-hi CursorColumn  guibg=#E5E6E6                gui=none  ctermbg=bg    cterm=none
-hi CursorLine    guibg=#E5E6E6                gui=none  ctermbg=bg    cterm=none
+hi CursorColumn  guibg=#E5E6E6                gui=none  ctermbg=253    cterm=none
+hi CursorLine    guibg=#E5E6E6                gui=none  ctermbg=253    cterm=none
 
 hi DiffAdd       guifg=#10A778    guibg=NONE     ctermfg=darkgreen  ctermbg=bg
 hi DiffDelete    guifg=#C30771    guibg=NONE     ctermfg=darkred    ctermbg=bg


### PR DESCRIPTION
Nice work on the pencil theme! I've made an iTerm version of it as well, will be uploading it shortly. Anyway I use vim in the terminal under tmux and some things weren't looking quite right. Here's a summary of my changes, take them for what you will:

```
Error         This wasn't standing out enough, emboldened.

TODO          Was showing up as white on light grey, now on red.

ColorColumn   The `ctermbg` was simply set to the regular background and the
              foreground highlighting was a middle-grey.  This produced
              odd-looking off-color characters that seemed like some sort of
              error on the occasional ragged line.  Adjusted `ctermbg` to be
              similar to the guibg, and disabled the foreground highlighting.
              If you want to disable this, you can do so with `set colorcolumn=0`

CursorColumn  Was set to no highlighting.  This is a useful feature for
              whitespace-sensitive languages like Python or CoffeeScript, and if
              you want to disable it you can do so with `set nocursorcolumn`

CursorLine    Was set to no highlighting.  This is a useful feature for code in
              general.  If you want to disable it you can do so with
              `set nocursorline`
```
