### PR TITLE
Update highlight groups for plasticboy/vim-markdown

### DIFF
--- a/colors/pencil.vim
+++ b/colors/pencil.vim
@@ -323,7 +323,7 @@ call s:h("markdownCode",                {"fg": s:norm, "bg": s:code_bg})
 call s:h("markdownCodeDelimiter",       {"fg": s:norm, "bg": s:code_bg})
 
 " plasticboy/vim-markdown
-call s:h("mkdBlockQuote",               {"fg": s:norm})
+call s:h("mkdBlockquote",               {"fg": s:norm})
 call s:h("mkdDelimiter",                {"fg": s:medium_gray})
 call s:h("mkdID",                       {"fg": s:medium_gray})
 call s:h("mkdLineContinue",             {"fg": s:norm})
@@ -332,7 +332,7 @@ call s:h("mkdLinkDef",                  {"fg": s:medium_gray})
 call s:h("mkdListItem",                 {"fg": s:norm})
 call s:h("mkdNonListItemBlock",         {"fg": s:norm})  " bug in syntax?
 call s:h("mkdRule",                     {"fg": s:norm})
-call s:h("mkdUrl",                      {"fg": s:medium_gray, "gui": "underline", "cterm": "underline"})
+call s:h("mkdURL",                      {"fg": s:medium_gray, "gui": "underline", "cterm": "underline"})
 call s:h("mkdCode",                     {"fg": s:norm, "bg": s:code_bg})
 call s:h("mkdIndentCode",               {"fg": s:norm, "bg": s:code_bg})
 

--- a/colors/pencil.vim
+++ b/colors/pencil.vim
@@ -326,7 +326,6 @@ call s:h("markdownCodeDelimiter",       {"fg": s:norm, "bg": s:code_bg})
 call s:h("mkdBlockquote",               {"fg": s:norm})
 call s:h("mkdDelimiter",                {"fg": s:medium_gray})
 call s:h("mkdID",                       {"fg": s:medium_gray})
-call s:h("mkdLineContinue",             {"fg": s:norm})
 call s:h("mkdLink",                     {"fg": s:norm})
 call s:h("mkdLinkDef",                  {"fg": s:medium_gray})
 call s:h("mkdListItem",                 {"fg": s:norm})
@@ -334,7 +333,6 @@ call s:h("mkdNonListItemBlock",         {"fg": s:norm})  " bug in syntax?
 call s:h("mkdRule",                     {"fg": s:norm})
 call s:h("mkdURL",                      {"fg": s:medium_gray, "gui": "underline", "cterm": "underline"})
 call s:h("mkdCode",                     {"fg": s:norm, "bg": s:code_bg})
-call s:h("mkdIndentCode",               {"fg": s:norm, "bg": s:code_bg})
 
 " gabrielelana/vim-markdown
 call s:h("markdownBlockquoteDelimiter", {"fg": s:norm})


### PR DESCRIPTION
The important change is that `mkdUrl` should be `mkdURL`. This caused `plasticboy/vim-markdown`'s gx and ge mappings (opening links) to not work, since it uses case sensitive matching on the name of the highlight group.

The rest is just some highlight groups I noticed are no longer used, plus capitalization of `mkdBlockquote`.